### PR TITLE
display namespace when recursive option is used

### DIFF
--- a/src/GitLab.re
+++ b/src/GitLab.re
@@ -12,6 +12,7 @@ type project = {
   name: string,
   web_url: string,
   archived: bool,
+  name_with_namespace: string,
 };
 
 type searchFilter =
@@ -45,6 +46,7 @@ module Decode = {
     name: json |> field("name", string),
     web_url: json |> field("web_url", string),
     archived: json |> field("archived", bool),
+    name_with_namespace: json |> field("name_with_namespace", string),
   };
   let projects = json => json |> array(project);
 

--- a/src/Main.re
+++ b/src/Main.re
@@ -22,7 +22,7 @@ let main = (args, options) => {
     |> then_(GitLab.fetchProjectsInGroups(getOption("archive"), getOption("recursive")))
     |> then_(GitLab.searchInProjects(criterias))
     |> then_(results =>
-         resolve(Print.searchResults(criterias.term, results))
+         resolve(Print.searchResults(criterias.term, results, getOption("recursive")))
        )
     |> catch(err => resolve(Js.log2("Something exploded!", err)))
     |> ignore

--- a/src/Print.re
+++ b/src/Print.re
@@ -27,6 +27,7 @@ let searchResults =
     (
       term: string,
       results: array((GitLab.project, array(GitLab.searchResult))),
+      isRecursive: option(string),
     ) => {
   Array.forEach(
     results,
@@ -42,8 +43,12 @@ let searchResults =
         );
 
       let archivedInfo = project.archived ? bold(red(" (archived)")) : "";
+      let displayName = switch (isRecursive) {
+        | None => project.name;
+        | _ => project.name_with_namespace;
+      };
 
-      Js.log(bold(green(project.name ++ archivedInfo ++ ":")));
+      Js.log(bold(green(displayName ++ archivedInfo ++ ":")));
       Js.log(formattedResults);
     },
   );


### PR DESCRIPTION
Hello,

I thought it might be more convenient to display the project name including the namespace when we use --recursive option (in case of same project name in several groups, for instance)

What do you think ?